### PR TITLE
ci(release): add semantic-release GitHub Actions workflow using app token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for semantic-release to create releases/tags
+      issues: write   # for semantic-release to comment on issues
+      pull-requests: write # for semantic-release to comment on PRs
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Generate a GitHub App token for releases (more secure than default GITHUB_TOKEN)
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Semantic Release
+        uses: ahmadnassri/action-semantic-release@v2
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Makefile
 .PHONY: init run-pre-commit build exec dev npm npx test test/smoke test/e2e test/e2e/headless clean down up logs
 
-NUXT_APP_DIR = comic-safe
-DOCKER_DEV_IMAGE = comic-safe-dev
-DOCKER_PROD_IMAGE = comic-safe-prod
-DOCKER_DEV_CONTAINER = comic-safe-dev-test
+NUXT_APP_DIR ?= comic-safe
+DOCKER_DEV_IMAGE ?= comic-safe-dev
+DOCKER_PROD_IMAGE ?= comic-safe-prod
+DOCKER_DEV_CONTAINER ?= comic-safe-dev-test
 
 init:
 	pre-commit install
@@ -75,4 +75,4 @@ run/dev:
 	docker compose up
 
 run/prod: build/prod
-	docker run --rm -it -p 3000:3000 comic-safe-prod
+	docker run --rm -it -p 3000:3000 $(DOCKER_PROD_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,14 @@ init:
 run-pre-commit:
 	pre-commit run --all-files
 
-build:
-	docker build -t $(DOCKER_DEV_IMAGE) $(NUXT_APP_DIR)
+# --- Build Targets ---
+build: build/dev
+
+build/dev:
+	docker compose build
+
+build/prod:
+	docker build -t comic-safe-prod --target=prod comic-safe
 
 exec: build
 	docker run --rm -it \
@@ -60,3 +66,10 @@ test/e2e/headless:
 
 logs:
 	docker compose logs -f nuxtapp
+
+# --- Run Targets ---
+run/dev:
+	docker compose up
+
+run/prod:
+	docker run --rm -it -p 3000:3000 comic-safe-prod

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 NUXT_APP_DIR = comic-safe
 DOCKER_DEV_IMAGE = comic-safe-dev
+DOCKER_PROD_IMAGE = comic-safe-prod
 DOCKER_DEV_CONTAINER = comic-safe-dev-test
 
 init:
@@ -18,7 +19,7 @@ build/dev:
 	docker compose build
 
 build/prod:
-	docker build -t comic-safe-prod --target=prod comic-safe
+	docker build -t $(DOCKER_PROD_IMAGE) --target=prod comic-safe
 
 exec: build
 	docker run --rm -it \
@@ -46,6 +47,8 @@ npx: build
 
 clean:
 	docker compose down -v
+	docker rmi $(DOCKER_DEV_IMAGE)
+	docker rmi $(DOCKER_PROD_IMAGE)
 
 down:
 	docker compose down
@@ -71,5 +74,5 @@ logs:
 run/dev:
 	docker compose up
 
-run/prod:
+run/prod: build/prod
 	docker run --rm -it -p 3000:3000 comic-safe-prod

--- a/comic-safe/.dockerignore
+++ b/comic-safe/.dockerignore
@@ -1,7 +1,9 @@
 node_modules
-.nuxt
 .output
-.env
-npm-debug.log
+.nuxt
+.git
+tests
+*.log
 Dockerfile
 docker-compose.yml
+.env

--- a/comic-safe/Dockerfile
+++ b/comic-safe/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:20
+# --- Base image with Puppeteer/Chromium dependencies (for both dev and prod) ---
+FROM node:20 AS base
 
-# Install Puppeteer/Chromium dependencies
 RUN apt-get update && apt-get install -y \
     libnss3 \
     libatk-bridge2.0-0 \
@@ -15,17 +15,36 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
+# --- Development stage (default) ---
+FROM base AS dev
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
 RUN if [ -f package-lock.json ]; then npm ci; \
     elif [ -f pnpm-lock.yaml ]; then corepack enable && pnpm install; \
     elif [ -f yarn.lock ]; then yarn install; \
     else npm install; fi
-
 COPY . .
-
 EXPOSE 3000
-
 CMD ["npx", "nuxt", "dev"]
+
+# --- Build stage ---
+FROM base AS build
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+RUN if [ -f package-lock.json ]; then npm ci; \
+    elif [ -f pnpm-lock.yaml ]; then corepack enable && pnpm install; \
+    elif [ -f yarn.lock ]; then yarn install; \
+    else npm install; fi
+COPY . .
+RUN npm run build
+
+# --- Production stage ---
+FROM base AS prod
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build /app/.output .output
+COPY --from=build /app/package.json ./
+COPY --from=build /app/node_modules ./node_modules
+EXPOSE 3000
+CMD ["node", ".output/server/index.mjs"]
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=5 \
   CMD curl -f http://localhost:3000 || exit 1

--- a/comic-safe/Dockerfile
+++ b/comic-safe/Dockerfile
@@ -1,6 +1,5 @@
-# --- Base image with Puppeteer/Chromium dependencies (for both dev and prod) ---
+# --- Base stage: system dependencies, lockfiles, working dir ---
 FROM node:20 AS base
-
 RUN apt-get update && apt-get install -y \
     libnss3 \
     libatk-bridge2.0-0 \
@@ -12,12 +11,11 @@ RUN apt-get update && apt-get install -y \
     libgtk-3-0 \
     libasound2 \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
-
-# --- Development stage (default) ---
-FROM base AS dev
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+
+# --- Dev stage: all deps, full source, dev server ---
+FROM base AS dev
 RUN if [ -f package-lock.json ]; then npm ci; \
     elif [ -f pnpm-lock.yaml ]; then corepack enable && pnpm install; \
     elif [ -f yarn.lock ]; then yarn install; \
@@ -26,22 +24,19 @@ COPY . .
 EXPOSE 3000
 CMD ["npx", "nuxt", "dev"]
 
-# --- Build stage ---
-FROM base AS build
-COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
-RUN if [ -f package-lock.json ]; then npm ci; \
-    elif [ -f pnpm-lock.yaml ]; then corepack enable && pnpm install; \
-    elif [ -f yarn.lock ]; then yarn install; \
-    else npm install; fi
-COPY . .
-RUN npm run build
+# --- Build stage: extends dev, builds app, prunes dev deps ---
+FROM dev AS build
+RUN npm run build \
+ && if [ -f package-lock.json ]; then npm prune --omit=dev; \
+    elif [ -f pnpm-lock.yaml ]; then corepack enable && pnpm prune --prod; \
+    elif [ -f yarn.lock ]; then yarn install --production --ignore-scripts; \
+    else npm prune --omit=dev; fi
 
-# --- Production stage ---
+# --- Prod stage: extends base, only copies built output and prod deps ---
 FROM base AS prod
-ENV NODE_ENV=production
-WORKDIR /app
 COPY --from=build /app/.output .output
 COPY --from=build /app/package.json ./
+COPY --from=build /app/package-lock.json* ./
 COPY --from=build /app/node_modules ./node_modules
 EXPOSE 3000
 CMD ["node", ".output/server/index.mjs"]

--- a/comic-safe/pages/comics/[slug]/[issue].vue
+++ b/comic-safe/pages/comics/[slug]/[issue].vue
@@ -20,6 +20,7 @@
 <script setup>
 import { ref } from 'vue'
 import { useRoute } from 'vue-router'
+import { onMounted, onUnmounted } from 'vue'
 const route = useRoute()
 const slug = route.params.slug
 const issue = route.params.issue
@@ -40,6 +41,21 @@ function prevPage() {
 function nextPage() {
   if (images.value && currentIndex.value < images.value.length - 1) currentIndex.value++
 }
+
+function handleKeydown(e) {
+  if (e.key === 'ArrowRight') {
+    nextPage()
+  } else if (e.key === 'ArrowLeft') {
+    prevPage()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+})
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
 </script>
 
 <style>

--- a/comic-safe/pages/comics/[slug]/index.vue
+++ b/comic-safe/pages/comics/[slug]/index.vue
@@ -5,7 +5,7 @@
     <div v-else-if="error">Failed to load issues: {{ error.message }}</div>
     <ul v-else>
       <li v-for="issue in issues" :key="issue.url">
-        <a :href="issue.url" target="_blank">{{ issue.title }}</a>
+        <NuxtLink :to="toLocalIssue(issue.url)">{{ issue.title }}</NuxtLink>
         <span style="color: #888; margin-left: 1em;">{{ issue.date }}</span>
       </li>
     </ul>
@@ -21,6 +21,18 @@ const { data: issues, pending, error } = await useAsyncData(
   `issues-${slug}`,
   () => $fetch(`/api/comics/${slug}`)
 )
+
+function toLocalIssue(url) {
+  // Example: /Comic/Injustice-2/Annual-1?id=125858
+  const match = url.match(/\/Comic\/([^/]+)\/([^?]+)(\?id=\d+)?/)
+  if (match) {
+    const slug = match[1]
+    const issue = match[2]
+    const id = match[3] || ''
+    return `/comics/${slug}/${issue}${id}`
+  }
+  return url // fallback
+}
 </script>
 
 <style>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,16 @@ services:
     build:
       context: ./comic-safe
       dockerfile: Dockerfile
+      target: dev
     container_name: comic-safe-dev-test
     image: comic-safe-dev
     ports:
       - "3000:3000"
+    environment: {}
+    working_dir: /app
     volumes:
       - ./comic-safe:/app
       - nuxt_node_modules:/app/node_modules
-    environment: {}
-    working_dir: /app
     command: npx nuxt dev
 volumes:
   nuxt_node_modules:


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for semantic-release using ahmadnassri/action-semantic-release and actions/create-github-app-token for secure release automation. The workflow triggers on push to main and uses a GitHub App token for permissions. No .releaserc is included, so semantic-release will use its defaults.