### PR TITLE
chore(release): specify main as release branch for semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,3 @@
+{
+  "branches": ["main"]
+}


### PR DESCRIPTION
Add a minimal .releaserc.json to explicitly set 'main' as the release branch for semantic-release, resolving ERELEASEBRANCHES errors in CI.