### PR TITLE
ci(release): use docker/metadata-action for robust Docker image tagging and publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,30 +2,67 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
-  workflow_dispatch:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   release:
+    name: Create Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # for semantic-release to create releases/tags
-      issues: write   # for semantic-release to comment on issues
-      pull-requests: write # for semantic-release to comment on PRs
-
+    outputs:
+      published: ${{ steps.release.outputs.published }}
+      release-git-tag: ${{ steps.release.outputs.release-git-tag }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      # Generate a GitHub App token for releases (more secure than default GITHUB_TOKEN)
-      - name: Generate GitHub App token
+      - uses: actions/create-github-app-token@v2
         id: app-token
-        uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-
-      - name: Semantic Release
-        uses: ahmadnassri/action-semantic-release@v2
+          owner: ${{ github.repository_owner }}
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Release
+        id: release
+        uses: ahmadnassri/action-semantic-release@v2.2.8
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  docker:
+    needs: release
+    if: ${{ needs.release.outputs.published == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.release-git-tag }}
+            type=sha
+            type=ref,event=branch
+      - name: Build and push Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          IMAGE=ghcr.io/${{ github.repository }}
+          docker buildx build \
+            --platform linux/amd64 \
+            --tag $IMAGE:${{ needs.release.outputs.release-git-tag }} \
+            $(echo $TAGS | xargs -n 1 echo --tag) \
+            --push \
+            .

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,3 +1,45 @@
 {
-  "branches": ["main"]
+  "branches": ["main"],
+  "tagFormat": "${version}",
+  "repositoryUrl": "https://github.com/surefirev2/comic-reader.git",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "revert": true, "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "build", "section": "Build", "hidden": false },
+            { "type": "chore", "section": "Chores", "hidden": false },
+            { "type": "ci", "section": "CI/CD", "hidden": false },
+            { "type": "docs", "section": "Docs", "hidden": false },
+            { "type": "feat", "section": "Features", "hidden": false },
+            { "type": "fix", "section": "Bug Fixes", "hidden": false },
+            { "type": "perf", "section": "Performance", "hidden": false },
+            { "type": "refactor", "section": "Refactor", "hidden": false },
+            { "type": "style", "section": "Code Style", "hidden": false },
+            { "type": "test", "section": "Tests", "hidden": false }
+          ]
+        }
+      }
+    ],
+    "@semantic-release/github"
+  ]
 }


### PR DESCRIPTION
Update the release workflow to use docker/metadata-action for automatic Docker image tagging and robust publishing to GHCR. This ensures all relevant tags (semver, SHA, branch) are applied to the image and pushed on release.